### PR TITLE
Increased width on togglebuttons to prevent overlapping & inverted graphics selection

### DIFF
--- a/src/components/MapHeader.vue
+++ b/src/components/MapHeader.vue
@@ -4,7 +4,7 @@
         <div class="control_bar">
         <div class="control_group">
             <div class="control_label">Rounds: </div>
-            <vue-slider 
+            <vue-slider
             v-model="slider_round"
             :max="maxRounds-1"
             :min="0"
@@ -13,7 +13,7 @@
             :adsorb="true"
             :lazy="true"
             :maxRange="1"
-            @change="setRound" 
+            @change="setRound"
             >
             <template v-slot:step="{active}">
                 <div :class="['custom-step', {active}]"></div>
@@ -21,12 +21,30 @@
             </vue-slider>
         </div>
         <div class="control_group">
-            <ToggleButton :value="false" :labels="{checked:'    Simple', unchecked:'Detail    '}" 
-            @change="setSimpleMode($event)" :width="80" :height="30" :font-size="17"/>
-            <ToggleButton :value="true" :labels="{checked:'    Zones', unchecked:'Zones    '}" 
-            @change="setZoneLabelVisibility($event)" :width="80" :height="30" :font-size="17"/>
-            <ToggleButton :value="false" :labels="{checked:'    Items', unchecked:'Items    '}" 
-            @change="setItemVisibility($event)" :width="80" :height="30" :font-size="17"/>
+            <ToggleButton
+              :value="true"
+              :labels="{checked:'Graphics', unchecked:'Graphics'}"
+              :width="115"
+              :height="30"
+              :font-size="17"
+              @change="setGraphicVisibility($event)"
+            />
+            <ToggleButton
+              :value="true"
+              :labels="{checked:'Zones', unchecked:'Zones'}"
+              :width="115"
+              :height="30"
+              :font-size="17"
+              @change="setZoneLabelVisibility($event)"
+            />
+            <ToggleButton
+              :value="true"
+              :labels="{checked:'Items', unchecked:'Items'}"
+              :width="115"
+              :height="30"
+              :font-size="17"
+              @change="setItemVisibility($event)"
+            />
         </div>
         </div>
     </div>
@@ -44,7 +62,7 @@ import {ToggleButton} from 'vue-js-toggle-button'
 import {extractAndProcessParams} from '../common/queryRoute.js'
 
 import {CURRENT_ZONE_FIGHT, NUMBER_OF_ROUNDS, CURRENT_ROUND} from '../state/getters'
-import {SET_SIMPLE_MODE, CHANGE_ROUND, OPT_SET_ZONE_VISIBILITY, OPT_SET_ITEM_VISIBILITY} from '../state/mutations'
+import {CHANGE_ROUND, OPT_SET_GRAPHIC_VISIBILITY, OPT_SET_ZONE_VISIBILITY, OPT_SET_ITEM_VISIBILITY} from '../state/mutations'
 
 
 export default {
@@ -59,11 +77,11 @@ export default {
         VueSlider
     },
     methods:{
-        setSimpleMode: function({value}){
-            this.$store.commit(SET_SIMPLE_MODE, value)
-        },
         setRound: function(value){
             this.$store.commit(CHANGE_ROUND, value)
+        },
+        setGraphicVisibility: function({value}){
+            this.$store.commit(OPT_SET_GRAPHIC_VISIBILITY, value)
         },
         setZoneLabelVisibility: function({value}){
             this.$store.commit(OPT_SET_ZONE_VISIBILITY, value)
@@ -107,7 +125,7 @@ h1{
   padding-top:.3em;
   padding-bottom: .5em;
   justify-content: center;
-  
+
 }
 
 .control_bar > div {

--- a/src/components/MapTile.vue
+++ b/src/components/MapTile.vue
@@ -37,11 +37,11 @@
                 <img :src="itemPicture" id="items" class="fieldItem" v-if="shouldShowItems" draggable="false"/>
             </transition>
             <transition name="fall">
-                <img :src="mapTilePath" v-if="!simple_mode"
+                <img :src="mapTilePath" v-if="graphicsFilter"
                     v-bind:class="{pyreOwned: pyreOwned, unOwned: unowned}" class="terrainTile" :style="fallTimeStyle" draggable="false">
             </transition>
             <transition name="fall">
-                <img src="../assets/pics/simple_tile/simple_tile.png" v-if="simple_mode"
+                <img src="../assets/pics/simple_tile/simple_tile.png" v-if="!graphicsFilter"
                     v-bind:class="{pyreOwned: pyreOwned, unOwned: unowned}" class="simple" :style="fallTimeStyle" draggable="false">
             </transition>
         </div>
@@ -61,9 +61,9 @@
 
 import {mapGetters} from 'vuex'
 import {NEW_SELECTED} from '../state/mutations'
-import {TILE_OWNER, SELECTING_GETTER, SIMPLE_MODE, 
+import {TILE_OWNER, SELECTING_GETTER,
     CURRENT_ZONE_CONTESTED, CURRENT_ZONE_GRANDBATTLE, CUR_ZONE_ID, SHOW_ZONE_LABEL, CURRENT_ZONE_NAME, CUR_ZONE_ATTACKER, ROUND_GRANDBATTLES,
-     TILE_IS_CLASH, CURRENT_ZONE_ITEMS, OPT_SHOW_ITEMS, OPT_SHOW_LABELS} from '../state/getters'
+     TILE_IS_CLASH, CURRENT_ZONE_ITEMS, OPT_SHOW_GRAPHICS, OPT_SHOW_ITEMS, OPT_SHOW_LABELS} from '../state/getters'
 
 const letters = [' ','a','b','c','d','e','f','g','h','i','j','k','l','m','n']
 
@@ -141,7 +141,7 @@ export default {
             return this.grandBattles.includes(this.curZoneId(this.title))
         },
         neBorder: function(){
-            if(!this.simple_mode) return false
+            if(this.graphicsFilter) return false
             var num = parseInt(this.title.slice(1))
             var letter = this.title[0]
             if(num + 1 > 14) return true
@@ -150,7 +150,7 @@ export default {
             return this.curZoneId(this.title) !== this.curZoneId(other)
         },
         swBorder: function(){
-            if(!this.simple_mode) return false
+            if(this.graphicsFilter) return false
             var num = parseInt( this.title.slice(1))
             var letter = this.title[0]
             if(num - 1 < 1) return true
@@ -159,7 +159,7 @@ export default {
             return this.curZoneId(this.title) !== this.curZoneId(other)
         },
         nwBorder: function(){
-            if(!this.simple_mode) return false
+            if(this.graphicsFilter) return false
             var num = parseInt(this.title.slice(1))
             var letter = this.title[0]
             var iletter = letters.findIndex(l => l === letter)
@@ -169,7 +169,7 @@ export default {
             return this.curZoneId(this.title) !== this.curZoneId(other)
         },
         seBorder: function(){
-            if(!this.simple_mode) return false
+            if(this.graphicsFilter) return false
             var num = parseInt(this.title.slice(1))
             var letter = this.title[0]
             var iletter = letters.findIndex(l => l === letter)
@@ -181,7 +181,6 @@ export default {
         ...mapGetters({
             tileOwner: TILE_OWNER,
             selected: SELECTING_GETTER,
-            simple_mode: SIMPLE_MODE,
             isContested: CURRENT_ZONE_CONTESTED,
             isGrandBattle: CURRENT_ZONE_GRANDBATTLE,
             isClash: TILE_IS_CLASH,
@@ -192,7 +191,8 @@ export default {
             grandBattles: ROUND_GRANDBATTLES,
             items: CURRENT_ZONE_ITEMS,
 
-            itemFilter: OPT_SHOW_ITEMS, 
+            graphicsFilter: OPT_SHOW_GRAPHICS,
+            itemFilter: OPT_SHOW_ITEMS,
             zoneFilter: OPT_SHOW_LABELS,
         })
 
@@ -211,7 +211,7 @@ export default {
             this.$store.commit(NEW_SELECTED, this.title)
             //need to let the dom claim the space before scrolling
             // setTimeout(function(){
-            //     window.scrollTo({top: window.innerHeight *.8, behavior: 'smooth'}) 
+            //     window.scrollTo({top: window.innerHeight *.8, behavior: 'smooth'})
             // },200)
         }
     }

--- a/src/state/baseState.js
+++ b/src/state/baseState.js
@@ -5,11 +5,10 @@ import allBackstories from '../assets/data/backstories.json'
 import fighters from './fighter-loader'
 
 const defaultState = {
-    
+
     curSelected: "NA",
     curRound:0,
     roundData: allRounds,
-    simpleMode: false,
     metaMap: mapMeta,
     zoneDesc: zoneInfo,
     allFighters: fighters,
@@ -17,8 +16,9 @@ const defaultState = {
     localStorageAvailable: null,
     readingList:{},
     backstories: allBackstories,
-    showLabels: true,
-    showItems: false,
+    showGraphics: true,
+    showItems: true,
+    showLabels: true
 }
 
 export default defaultState;

--- a/src/state/getters.js
+++ b/src/state/getters.js
@@ -1,9 +1,8 @@
 const getters = {
     selecting: state => state.curSelected,
     round: state => state.curRound,
-    simple_mode: state => state.simpleMode,
     curRoundBoard: state => state.roundData[state.curRound],
-    
+
     tileState: (state) => (tileName) => {
         return state.roundData[state.curRound][tileName];
     },
@@ -101,6 +100,9 @@ const getters = {
     },
     showLabels: (state) =>{
         return state.showLabels
+    },
+    showGraphics: (state) =>{
+        return state.showGraphics
     }
 
 }
@@ -111,7 +113,6 @@ const SELECTING_GETTER = 'selecting'
 const FIGHTER_GETTER = 'fighter'
 const CURRENT_ROUND = 'round'
 const TILE_OWNER = 'tileOwner'
-const SIMPLE_MODE = 'simple_mode'
 const CURRENT_ZONE_NAME = 'curZoneName'
 const CURRENT_ZONE_DESC = 'curZoneDesc'
 const CURRENT_ZONE_CONTESTED = 'curZoneContested'
@@ -130,12 +131,13 @@ const CURZONE_IS_CLASH = 'curZoneIsClash'
 const TILE_IS_CLASH = 'tileIsClash'
 const FIGHTER_BACKSTORY = 'fighterBackstory'
 
+const OPT_SHOW_GRAPHICS = 'showGraphics'
 const OPT_SHOW_ITEMS = 'showItems'
 const OPT_SHOW_LABELS = 'showLabels'
 
 const HAS_READ_COMIC = 'hasReadFightersComic'
 
-export {SELECTING_GETTER, CURRENT_ROUND, TILE_OWNER, SIMPLE_MODE, CURRENT_ZONE_NAME, CURRENT_ZONE_DESC, CURRENT_ZONE_CONTESTED, 
+export {SELECTING_GETTER, CURRENT_ROUND, TILE_OWNER, OPT_SHOW_GRAPHICS, CURRENT_ZONE_NAME, CURRENT_ZONE_DESC, CURRENT_ZONE_CONTESTED,
     CURRENT_ZONE_GRANDBATTLE, CURRENT_ZONE_FIGHT, FIGHTER_GETTER, CUR_FIGHTER_LINK, CUR_SPOILER_REVEALED, CUR_ZONE_ID, SHOW_ZONE_LABEL, NUMBER_OF_ROUNDS
     ,CUR_ZONE_ATTACKER, ROUND_GRANDBATTLES, MASSBATTLE_FIGHTERS, CURZONE_IS_CLASH, TILE_IS_CLASH, HAS_READ_COMIC, FIGHTER_BACKSTORY, CURRENT_ZONE_ITEMS,
     OPT_SHOW_ITEMS, OPT_SHOW_LABELS}

--- a/src/state/mutations.js
+++ b/src/state/mutations.js
@@ -7,8 +7,8 @@ const mutations = {
     deSelect(state){
         state.curSelected = 'NA'
     },
-    setSimpleMode(state, newVal){
-        state.simpleMode = newVal
+    setGraphicVisibility(state, newVal){
+        state.showGraphics = newVal
     },
     setCurrentRound(state, newVal){
         if(isNaN(newVal)) {
@@ -79,7 +79,6 @@ const mutations = {
 export default mutations;
 
 const NEW_SELECTED = 'newSelected'
-const SET_SIMPLE_MODE = 'setSimpleMode'
 const DESELECT = 'deSelect'
 const CHANGE_ROUND = 'setCurrentRound'
 const REVEAL_SPOILER = 'revealSpoiler'
@@ -88,8 +87,9 @@ const LS_AVAILABLE = 'localStorageAvailable'
 const MARK_READ = 'markAsRead'
 const MARK_UNREAD = 'unmarkAsRead'
 
+const OPT_SET_GRAPHIC_VISIBILITY = 'setGraphicVisibility'
 const OPT_SET_ZONE_VISIBILITY = 'setLabelVisibility'
 const OPT_SET_ITEM_VISIBILITY = 'setItemVisibility'
 
-export { NEW_SELECTED, SET_SIMPLE_MODE, DESELECT, CHANGE_ROUND, REVEAL_SPOILER, LS_INIT, LS_AVAILABLE, MARK_READ, MARK_UNREAD,
-    OPT_SET_ZONE_VISIBILITY, OPT_SET_ITEM_VISIBILITY}
+export { NEW_SELECTED, DESELECT, CHANGE_ROUND, REVEAL_SPOILER, LS_INIT, LS_AVAILABLE, MARK_READ, MARK_UNREAD,
+    OPT_SET_GRAPHIC_VISIBILITY, OPT_SET_ZONE_VISIBILITY, OPT_SET_ITEM_VISIBILITY}


### PR DESCRIPTION
Howdy,

I came across this magnificent little project after stumbling upon the recent People Make Games YouTube video and thought I'd have a crack at my first contribution to a piece of open source software. I'm not a front end guy either, so it's still small and still a bit dirty.

### Changes:

- Resized the togglebuttons to prevent the overlap issue between the text and pips

- Refactored the 'simple-mode' togglebutton to instead be a 'show graphics' one consistent with the others.
Previously ON meant to hide the graphics, whereas OFF showed them. Made more sense to me from a UX perspective to have all three buttons be consistent and control the _enabling_ of a feature.

- Enabled all 3 toggle buttons by default


### Before: 
![image](https://user-images.githubusercontent.com/16097487/120877702-5cd72980-c5fb-11eb-9db4-05750a4f0d6e.png)
### After: 
![image](https://user-images.githubusercontent.com/16097487/120877687-46c96900-c5fb-11eb-8879-31da8d493ec2.png)
